### PR TITLE
feat: allow function as setReplicant value

### DIFF
--- a/tests/use-replicant.spec.tsx
+++ b/tests/use-replicant.spec.tsx
@@ -75,7 +75,7 @@ interface RunnerNameProps {
 const RunnerName: React.FC<RunnerNameProps> = (props) => {
 	const {prefix} = props;
 	const repName = `${prefix ?? 'default'}:currentRun`;
-	const [currentRun] = useReplicant(repName, null, {
+	const [currentRun] = useReplicant(repName, {
 		defaultValue: {runner: {name: 'foo'}},
 	});
 	if (!currentRun) {
@@ -86,7 +86,7 @@ const RunnerName: React.FC<RunnerNameProps> = (props) => {
 
 // Example of a replicant with a mutating value.
 const Counter: React.FC = () => {
-	const [counter, setCounter] = useReplicant('counter', 0, {
+	const [counter, setCounter] = useReplicant<number>('counter', {
 		defaultValue: 0,
 	});
 	if (typeof counter !== 'number') return null;


### PR DESCRIPTION
BREAKING CHANGE: `initialValue` parameter is removed. The returned value type will always have `undefined`.

BREAKING CHANGE: `namespace` is renamed to `bundle`.