### PR TITLE
fix: add object arrays

### DIFF
--- a/src/use-replicant.ts
+++ b/src/use-replicant.ts
@@ -3,7 +3,7 @@ import { klona as clone } from "klona/json";
 
 type JsonValue = boolean | number | string | null;
 
-type Json = JsonValue | JsonValue[] | { [key: string]: Json };
+type Json = JsonValue | JsonValue[] | { [key: string]: Json } | Json[];
 
 export type UseReplicantOptions<T> = {
 	defaultValue?: T;

--- a/tests/use-replicant.spec.tsx
+++ b/tests/use-replicant.spec.tsx
@@ -72,10 +72,16 @@ interface RunnerNameProps {
 	prefix?: string;
 }
 
+type RunnerNameReplicant = {
+	runner: {
+		name: string;
+	};
+};
+
 const RunnerName: React.FC<RunnerNameProps> = (props) => {
 	const { prefix } = props;
 	const repName = `${prefix ?? "default"}:currentRun`;
-	const [currentRun] = useReplicant(repName, {
+	const [currentRun] = useReplicant<RunnerNameReplicant>(repName, {
 		defaultValue: { runner: { name: "foo" } },
 	});
 	if (!currentRun) {


### PR DESCRIPTION
Previously passing useReplicant an array of objects as the type it would fail even though that is valid JSON. This adds `Json[]` to the Json type to allow for this.

I also added a type to the test case.